### PR TITLE
Ignore IO errors for dictionary tests

### DIFF
--- a/brotli/test/Spec.hs
+++ b/brotli/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as CL
 import Codec.Compression.Brotli
 import Codec.Compression.Brotli.Internal
+import System.IO.Error
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
@@ -29,7 +30,7 @@ main = do
     , testCase "Empty string" $ sampleRoundTrip ""
     , testCase "Paragraph" $ sampleRoundTrip "What you need is an eclipse. However being a tidally locked planet you're not going to have a moon, at least your people would have been idiots for settling on a tidally locked planet with a moon as it would be unstable as discussed in this question: "
     , testCase "The dictionary" $ do
-        L.readFile "/usr/share/dict/words" >>= sampleRoundTrip
+        catchIOError (L.readFile "/usr/share/dict/words") (const $ pure "") >>= sampleRoundTrip
     , testCase "Long, really compressable" longReallyCompressable
     , testCase "Streaming" $ do
         (Consume c) <- compressor fastSettings

--- a/wai-middleware-brotli/test/Spec.hs
+++ b/wai-middleware-brotli/test/Spec.hs
@@ -8,6 +8,7 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Builder as Builder
 import Data.IORef
 import Data.Monoid
+import Data.String
 import Network.Wai
 import Network.Wai.Middleware.Brotli
 import Network.Wai.Internal
@@ -16,12 +17,13 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.Hspec
 import System.IO
+import System.IO.Error
 
 main :: IO ()
 main = do
   putStrLn ""
 
-  bod <- L.readFile "/usr/share/dict/words" -- "Hello World 000000000000000000000000000000"
+  bod <- catchIOError (L.readFile "/usr/share/dict/words") (const . pure . fromString $ "Hello World " ++ replicate 860 '0')
   let app req respond = respond $ responseLBS status200 [("Content-Type", "text/whatever")] bod
 
   specs <- testSpecs $ parallel $ do


### PR DESCRIPTION
Some Linux distros popular with Haskell users (e.g. NixOS) do not have a file at `/usr/share/dict/words`. In those cases, skipping the test is preferable to failure.

I've tried to keep the bypass as simple as possible. In the case of `wai-middleware-brotli`, the alternate test data should be effective too.